### PR TITLE
Update to 44.0

### DIFF
--- a/org.gnome.Extensions.json
+++ b/org.gnome.Extensions.json
@@ -1,7 +1,7 @@
 {
   "app-id": "org.gnome.Extensions",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "42beta",
+  "runtime-version": "44beta",
   "sdk": "org.gnome.Sdk",
   "command": "gnome-extensions-app",
   "finish-args": [
@@ -21,8 +21,8 @@
         {
           "type": "git",
           "url": "https://gitlab.gnome.org/GNOME/gnome-shell.git",
-          "tag": "42.0",
-          "commit": "44b4b02c3f772a50e6f8b8fd2dca6d9dc3a98725"
+          "tag": "44.0",
+          "commit": "b6a7cac28ff84fdaa99be08b64b0ff50b6cf4894"
         },
         {
           "type": "patch",


### PR DESCRIPTION
- Update to 41.rc
- Update to 41.0
- Drop 3.34 support
- Update to 42.beta
- Update to 42.rc
- Update to 42.0
- Update to 44.0
