### PR TITLE
Update to 46.beta

### DIFF
--- a/org.gnome.Extensions.json
+++ b/org.gnome.Extensions.json
@@ -1,7 +1,7 @@
 {
   "app-id": "org.gnome.Extensions",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "45beta",
+  "runtime-version": "46beta",
   "sdk": "org.gnome.Sdk",
   "command": "gnome-extensions-app",
   "finish-args": [
@@ -21,8 +21,8 @@
         {
           "type": "git",
           "url": "https://gitlab.gnome.org/GNOME/gnome-shell.git",
-          "tag": "45.0",
-          "commit": "2127c62b210f605747e019e6e2abee82516e3ccb"
+          "tag": "46.beta",
+          "commit": "fbe3c4120f5c0566f9276296a03a4949f89b7179"
         },
         {
           "type": "patch",


### PR DESCRIPTION
- Update to 41.rc
- Update to 41.0
- Drop 3.34 support
- Update to 42.beta
- Update to 42.rc
- Update to 42.0
- Update to 44.0
- Update to 45.beta.1
- Update to 45.rc
- Update to 45.0
- Update to 45.2
- Update to 45.3
- Update to 46.beta
